### PR TITLE
Add type-safe cross-origin iframe transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,29 @@ jobs:
       - name: Test with ReScript ${{ matrix.rescript-version }}
         run: make test
 
+  browser:
+    name: Cross-Origin Browser Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser tests
+        run: make test-browser
+
   quality:
     name: Code Quality & Security
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Run 'make help' to see available commands
 
 .DEFAULT_GOAL := help
-.PHONY: help install build clean dev test analyze lint format check publish setup-hooks
+.PHONY: help install build clean dev test test-browser analyze lint format check publish setup-hooks
 
 # Colors for output
 CYAN := \033[36m
@@ -39,6 +39,11 @@ test: build ## Run all tests
 	@printf "$(YELLOW)Running tests...$(RESET)\n"
 	node src/TestRunner.res.mjs
 	@printf "$(GREEN)Tests complete!$(RESET)\n"
+
+test-browser: build ## Run cross-origin browser tests
+	@printf "$(YELLOW)Running browser tests...$(RESET)\n"
+	node browser-tests/run.mjs
+	@printf "$(GREEN)Browser tests complete!$(RESET)\n"
 
 analyze: build ## Run ReScript dead code analysis
 	@printf "$(YELLOW)Analyzing ReScript code...$(RESET)\n"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,69 @@ let handler = (msg, _sender) => {
 }
 Runtime.OnMessage.addListener(handler)
 ```
+
+Bindings passed to `Runtime.Make` provide an ordered duplex transport. Reworker owns request correlation, timeouts, remote errors, casts, and chunking:
+
+```rescript
+module type MyBindings = {
+  type sender
+  let requestTimeoutMs: int
+  let postMessage: 'a => result<unit, string>
+  module OnMessage: {
+    let addListener: (('a, sender) => unit) => unit
+    let removeListener: (('a, sender) => unit) => unit
+  }
+  module OnClose: {
+    let addListener: (string => unit) => unit
+  }
+  let isOpen: unit => bool
+  let close: unit => unit
+}
+```
+
+`postMessage` must return `Error` when structured clone fails. `OnClose` must fire when the remote endpoint becomes unavailable so pending requests reject immediately.
+
+## Cross-Origin Iframes
+
+`WindowTransport` bootstraps a cross-origin iframe with `window.postMessage`, validates the exact origin and source window, and transfers a `MessagePort`. All Reworker messages then use that port.
+
+Create the parent binding with the iframe's non-null `contentWindow` and an explicit origin:
+
+```rescript
+module FrameBindings = WindowTransport.Parent.Make({
+  type targetWindow = Webapi.Dom.Window.t
+  type loadEvent = Webapi.Dom.Event.t
+  let targetOrigin = "https://frame.example.com"
+  let targetWindow = () => iframe->contentWindow
+  let addLoadListener = listener => iframe->addEventListener("load", listener)
+  let removeLoadListener = listener => iframe->removeEventListener("load", listener)
+  let requestTimeoutMs = 5000
+})
+
+module FrameRuntime = Runtime.Make(FrameBindings)
+
+await FrameBindings.connect()
+let title = await FrameRuntime.sendMessage(GetPageTitle)
+```
+
+Install the cooperating endpoint in the iframe before the parent connects:
+
+```rescript
+module ParentBindings = WindowTransport.Child.Make({
+  type parentWindow = Webapi.Dom.Window.t
+  let parentWindow = Webapi.Dom.window->Webapi.Dom.Window.parent
+  let parentOrigin = "https://parent.example.com"
+  let requestTimeoutMs = 5000
+})
+
+module ParentRuntime = Runtime.Make(ParentBindings)
+
+ParentRuntime.OnMessage.addListener(handler)
+ParentBindings.listen()->Result.getOrThrow
+```
+
+Both origins are mandatory and `"*"` is rejected. The parent binding reconnects with a new port after iframe navigation. Call `Runtime.close()` to reject pending requests and tear down the endpoint.
+
 Build a nice wrapper:
 In your background.res:
 ```rescript

--- a/browser-tests/run.mjs
+++ b/browser-tests/run.mjs
@@ -1,0 +1,167 @@
+import {createServer} from "node:http"
+import {mkdtemp, readFile, rm} from "node:fs/promises"
+import {tmpdir} from "node:os"
+import {join} from "node:path"
+import {build} from "esbuild"
+import {chromium} from "playwright"
+
+const host = "127.0.0.1"
+const parentPort = 4173
+const childPort = 4174
+const attackerPort = 4175
+const outputDirectory = await mkdtemp(join(tmpdir(), "reworker-browser-"))
+
+const assert = (condition, message) => {
+	if (!condition) {
+		throw new Error(message)
+	}
+}
+
+const listen = (port, render) => new Promise(resolve => {
+	const server = createServer((request, response) => {
+		const body = render(request.url)
+		response.writeHead(body === undefined ? 404 : 200, {
+			"content-type": request.url.endsWith(".js") ? "text/javascript" : "text/html",
+		})
+		response.end(body ?? "Not found")
+	})
+	server.listen(port, host, () => resolve(server))
+})
+
+const closeServer = server => new Promise((resolve, reject) => {
+	server.close(error => error === undefined ? resolve() : reject(error))
+})
+
+const childHtml = `<!doctype html><script type="module" src="/child.js"></script>`
+const parentHtml = `<!doctype html>
+<iframe id="child" src="http://${host}:${childPort}/child"></iframe>
+<script type="module" src="/parent.js"></script>`
+const wrongOriginHtml = `<!doctype html>
+<iframe id="child" src="http://${host}:${childPort}/child"></iframe>
+<script>
+window.attackReady = false
+document.querySelector("iframe").addEventListener("load", () => {
+	const channel = new MessageChannel()
+	channel.port1.onmessage = () => { window.attackReady = true }
+	document.querySelector("iframe").contentWindow.postMessage({
+		marker: "@bluehotdog/reworker/window/v1",
+		kind: "connect",
+		connectionId: "wrong-origin",
+	}, "http://${host}:${childPort}", [channel.port2])
+})
+</script>`
+const wrongSourceHtml = `<!doctype html>
+<iframe name="target" src="http://${host}:${childPort}/child"></iframe>
+<iframe name="sender" src="/sender"></iframe>
+<script>
+window.attackReady = false
+let loaded = 0
+for (const frame of document.querySelectorAll("iframe")) {
+	frame.addEventListener("load", () => {
+		loaded += 1
+		if (loaded === 2) frames.sender.forge(frames.target)
+	})
+}
+</script>`
+const senderHtml = `<!doctype html><script>
+window.forge = target => {
+	const channel = new MessageChannel()
+	channel.port1.onmessage = () => { parent.attackReady = true }
+	target.postMessage({
+		marker: "@bluehotdog/reworker/window/v1",
+		kind: "connect",
+		connectionId: "wrong-source",
+	}, "http://${host}:${childPort}", [channel.port2])
+}
+</script>`
+
+let browser
+let servers = []
+
+try {
+	await build({
+		entryPoints: ["src/WindowTransportParent__test.res.mjs"],
+		bundle: true,
+		format: "esm",
+		outfile: join(outputDirectory, "parent.js"),
+	})
+	await build({
+		entryPoints: ["src/WindowTransportChild__test.res.mjs"],
+		bundle: true,
+		format: "esm",
+		outfile: join(outputDirectory, "child.js"),
+	})
+
+	const parentBundle = await readFile(join(outputDirectory, "parent.js"))
+	const childBundle = await readFile(join(outputDirectory, "child.js"))
+	servers = await Promise.all([
+		listen(parentPort, path => {
+			if (path === "/parent.js") return parentBundle
+			if (path === "/sender") return senderHtml
+			if (path === "/wrong-source") return wrongSourceHtml
+			return parentHtml
+		}),
+		listen(childPort, path => path === "/child.js" ? childBundle : childHtml),
+		listen(attackerPort, () => wrongOriginHtml),
+	])
+
+	browser = await chromium.launch({headless: true})
+	const page = await browser.newPage()
+	await page.goto(`http://${host}:${parentPort}`)
+	await page.waitForFunction(() => window.reworkerTest !== undefined)
+	await page.evaluate(() => window.reworkerTest.connect())
+
+	assert(await page.evaluate(() => window.reworkerTest.ping("hello")) === "child:hello", "typed request failed")
+	assert(await page.evaluate(() => window.reworkerTest.reverse("hello")) === "parent:hello", "reverse request failed")
+
+	await page.evaluate(() => window.reworkerTest.cast("notice"))
+	await page.waitForFunction(async () => await window.reworkerTest.notice() === "notice")
+
+	const remoteError = await page.evaluate(async () => {
+		try { await window.reworkerTest.fail(); return "resolved" } catch (error) { return String(error) }
+	})
+	assert(remoteError.includes("Child handler failed"), "remote error did not reject")
+
+	const timeoutError = await page.evaluate(async () => {
+		try { await window.reworkerTest.timeout(); return "resolved" } catch (error) { return String(error) }
+	})
+	assert(timeoutError.includes("Request timed out"), "request timeout did not reject")
+
+	const cloneError = await page.evaluate(async () => {
+		try { await window.reworkerTest.uncloneable(); return "resolved" } catch (error) { return String(error) }
+	})
+	assert(cloneError !== "resolved", "structured clone failure did not reject")
+	assert(await page.evaluate(() => window.reworkerTest.large()), "chunked request failed")
+
+	const reloadError = await page.evaluate(async () => {
+		const pending = window.reworkerTest.timeout()
+		document.querySelector("iframe").src += "?reload=1"
+		try { await pending; return "resolved" } catch (error) { return String(error) }
+	})
+	assert(reloadError.includes("Iframe reloaded"), "iframe reload did not reject pending request")
+	await page.waitForFunction(() => window.reworkerTest.isOpen())
+	assert(await page.evaluate(() => window.reworkerTest.ping("again")) === "child:again", "reload did not reconnect")
+
+	const closeError = await page.evaluate(async () => {
+		const pending = window.reworkerTest.timeout()
+		window.reworkerTest.close()
+		try { await pending; return "resolved" } catch (error) { return String(error) }
+	})
+	assert(closeError.includes("Runtime closed"), "teardown did not reject pending request")
+
+	const wrongOriginPage = await browser.newPage()
+	await wrongOriginPage.goto(`http://${host}:${attackerPort}`)
+	await wrongOriginPage.waitForTimeout(700)
+	assert(!await wrongOriginPage.evaluate(() => window.attackReady), "incorrect origin was accepted")
+
+	const wrongSourcePage = await browser.newPage()
+	await wrongSourcePage.goto(`http://${host}:${parentPort}/wrong-source`)
+	await wrongSourcePage.waitForTimeout(700)
+	assert(!await wrongSourcePage.evaluate(() => window.attackReady), "incorrect source window was accepted")
+
+	console.log("Window transport browser tests passed")
+} finally {
+	if (browser !== undefined) await browser.close()
+	await Promise.all(servers.map(closeServer))
+	await rm(outputDirectory, {recursive: true, force: true})
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "0.0.2",
 			"license": "MIT",
 			"devDependencies": {
+				"esbuild": "^0.28.1",
+				"playwright": "^1.62.1",
 				"rescript": "^12.3.0"
 			},
 			"engines": {
@@ -16,6 +18,448 @@
 			},
 			"peerDependencies": {
 				"rescript": "^12.0.0"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@rescript/darwin-arm64": {
@@ -108,6 +552,95 @@
 			],
 			"engines": {
 				"node": ">=20.11.0"
+			}
+		},
+		"node_modules/esbuild": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+			"integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.62.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.62.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+			"integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/rescript": {

--- a/package.json
+++ b/package.json
@@ -43,11 +43,12 @@
 		"node": ">=20.11.0"
 	},
 	"sideEffects": false,
-	"dependencies": {},
 	"peerDependencies": {
 		"rescript": "^12.0.0"
 	},
 	"devDependencies": {
+		"esbuild": "^0.28.1",
+		"playwright": "^1.62.1",
 		"rescript": "^12.3.0"
 	},
 	"publishConfig": {

--- a/rescript.json
+++ b/rescript.json
@@ -3,7 +3,15 @@
 	"sources": {
 		"dir": "src",
 		"subdirs": true,
-		"public": ["Types", "Runtime", "Response", "Channel", "ChannelTypes", "Id"]
+		"public": [
+			"Types",
+			"Runtime",
+			"Response",
+			"Channel",
+			"ChannelTypes",
+			"Id",
+			"WindowTransport"
+		]
 	},
 	"package-specs": {
 		"module": "esmodule",

--- a/src/Runtime.res
+++ b/src/Runtime.res
@@ -3,88 +3,207 @@
  * SPDX-License-Identifier: MIT
  */
 
-// Generic Runtime wrapper for message passing with automatic chunking
-// Users provide their own messaging bindings (WebWorker, ServiceWorker, WXT, WebExtension-API, etc.)
-
 module type RuntimeBindings = {
   type sender
-  let sendMessage: 'a => Promise.t<'b>
+  let requestTimeoutMs: int
+  let postMessage: 'a => result<unit, string>
   module OnMessage: {
-    let addListener: (('a, sender, 'b => unit) => bool) => unit
-    let removeListener: (('a, sender, 'b => unit) => bool) => unit
+    let addListener: (('a, sender) => unit) => unit
+    let removeListener: (('a, sender) => unit) => unit
   }
-  let getRuntimeId: unit => option<string>
+  module OnClose: {
+    let addListener: (string => unit) => unit
+  }
+  let isOpen: unit => bool
+  let close: unit => unit
+}
+
+type protocolMessage =
+  | Request({id: Id.t, message: Obj.t})
+  | Cast(Obj.t)
+  | Success({id: Id.t, value: Obj.t})
+  | Failure({id: Id.t, message: string})
+
+type pendingRequest = {
+  resolve: Obj.t => unit,
+  reject: JsError.t => unit,
+  timeoutId: timeoutId,
+}
+
+@val external errorToString: 'a => string = "String"
+
+let exceptionMessage = error => {
+  error->JsExn.fromException->Option.flatMap(JsExn.message)->Option.getOr(errorToString(error))
 }
 
 module Make = (Bindings: RuntimeBindings) => {
-  // Type-safe handler mapping for removeListener functionality
+  let pendingRequests: Map.t<Id.t, pendingRequest> = Map.make()
   let handlerToWrapped: HandlerMap.t = HandlerMap.make()
+
+  let sendProtocolMessage = message => {
+    switch Bindings.postMessage(message) {
+    | Ok() => ()
+    | Error(message) => JsError.throwWithMessage(message)
+    }
+  }
+
+  let rejectPendingRequest = (id, message) => {
+    switch pendingRequests->Map.get(id) {
+    | Some(pending) => {
+        clearTimeout(pending.timeoutId)
+        pendingRequests->Map.delete(id)->ignore
+        pending.reject(JsError.make(message))
+      }
+    | None => ()
+    }
+  }
+
+  let responseHandler = (message, _sender) => {
+    switch (Obj.magic(message): protocolMessage) {
+    | Success({id, value}) =>
+      switch pendingRequests->Map.get(id) {
+      | Some(pending) => {
+          clearTimeout(pending.timeoutId)
+          pendingRequests->Map.delete(id)->ignore
+          pending.resolve(value)
+        }
+      | None => ()
+      }
+    | Failure({id, message}) => rejectPendingRequest(id, message)
+    | Request(_) | Cast(_) => ()
+    }
+  }
+
+  let closeHandler = reason => {
+    pendingRequests->Map.forEach(pending => {
+      clearTimeout(pending.timeoutId)
+      pending.reject(JsError.make(reason))
+    })
+    pendingRequests->Map.clear
+  }
+
+  Bindings.OnMessage.addListener(responseHandler)
+  Bindings.OnClose.addListener(closeHandler)
+
+  let sendRequest = (message: TransportMessage.t<'response>): Promise.t<'response> => {
+    let id = Id.make()
+    Promise.make((resolve, reject) => {
+      let timeoutId = setTimeout(() => {
+        rejectPendingRequest(id, "Request timed out")
+      }, Bindings.requestTimeoutMs)
+      pendingRequests->Map.set(
+        id,
+        {
+          resolve: value => resolve(Obj.magic(value)),
+          reject,
+          timeoutId,
+        },
+      )
+
+      try {
+        sendProtocolMessage(Request({id, message: Obj.magic(message)}))
+      } catch {
+      | error => rejectPendingRequest(id, exceptionMessage(error))
+      }
+    })
+  }
+
+  let rec sendChunks = async (chunks: array<Obj.t>, index): Obj.t => {
+    switch chunks->Array.get(index) {
+    | None => JsError.throwWithMessage("Chunked message did not contain a final chunk")
+    | Some(chunk) =>
+      if index === chunks->Array.length - 1 {
+        (await sendRequest(Obj.magic(chunk)))->Obj.magic
+      } else {
+        (await sendRequest(Obj.magic(chunk)))->ignore
+        await sendChunks(chunks, index + 1)
+      }
+    }
+  }
 
   let sendMessage:
     type a. Types.message<a> => Promise.t<a> =
     message => {
       if message->MessageChunker.shouldBeChunked {
-        let finalResp = ref(None)
-        TransportMessage.createChunks(message)
-        ->Array.mapWithIndex((chunkTransportMessage, index) => {
-          Bindings.sendMessage(chunkTransportMessage)->Promise.thenResolve(response => {
-            switch chunkTransportMessage {
-            | TransportMessage.FinalChunk(_chunk) => {
-                finalResp := Some(response)
-                ()
-              }
-            | TransportMessage.UserMessage(_) | TransportMessage.IntermediateChunk(_) => ()
-            }
-            (index, chunkTransportMessage, response)
-          })
-        })
-        ->Promise.all(_)
-        ->Promise.thenResolve(_results => finalResp.contents->Option.getOrThrow)
+        sendChunks(Obj.magic(TransportMessage.createChunks(message)), 0)->Promise.thenResolve(
+          Obj.magic,
+        )
       } else {
-        let transportMessage = TransportMessage.UserMessage(message)
-        Bindings.sendMessage(transportMessage)
+        sendRequest(TransportMessage.UserMessage(message))
       }
     }
 
-  // Fire-and-forget message sending (no response expected)
+  let castTransportMessage = message => {
+    try {
+      sendProtocolMessage(Cast(Obj.magic(message)))
+    } catch {
+    | error => Console.error2("Failed to cast message:", error)
+    }
+  }
+
   let cast:
     type a. Types.message<a> => unit =
     message => {
-      sendMessage(message)->Promise.ignore
+      if message->MessageChunker.shouldBeChunked {
+        TransportMessage.createChunks(message)->Array.forEach(castTransportMessage)
+      } else {
+        castTransportMessage(TransportMessage.UserMessage(message))
+      }
     }
 
-  // Message subscription with automatic chunk reassembly
   module OnMessage = {
     let addListener:
       type a. ((Types.message<a>, Bindings.sender) => Response.t<a>) => unit =
-      userResponseHandler => {
-        let messageHandler = (transportMessage, sender, sendResponse) => {
-          let response = RequestHandler.make(
-            ~userHandler=userResponseHandler,
-            transportMessage,
-            sender,
-          )
+      userHandler => {
+        let messageHandler = (protocolMessage, sender) => {
+          let handleTransportMessage = transportMessage => {
+            RequestHandler.make(~userHandler, transportMessage, sender)
+          }
 
-          // Convert Response.t to Chrome callback pattern
-          switch response {
-          | Response.RespondNow(value) =>
-            sendResponse(value)
-            false // Synchronous response
-          | Response.RespondLater(promise) =>
-            promise
-            ->Promise.then(value => {
-              sendResponse(value)
-              Promise.resolve()
-            })
-            ->ignore
-            true // Asynchronous response
-          | Response.NoResponse => false // No response
+          switch (Obj.magic(protocolMessage): protocolMessage) {
+          | Request({id, message}) =>
+            try {
+              switch handleTransportMessage(Obj.magic(message)) {
+              | Response.RespondNow(value) =>
+                sendProtocolMessage(Success({id, value: Obj.magic(value)}))
+              | Response.RespondLater(promise) =>
+                promise
+                ->Promise.thenResolve(value => {
+                  sendProtocolMessage(Success({id, value: Obj.magic(value)}))
+                })
+                ->Promise.catch(error => {
+                  sendProtocolMessage(
+                    (Failure({id, message: exceptionMessage(error)}): protocolMessage),
+                  )
+                  Promise.resolve()
+                })
+                ->ignore
+              | Response.NoResponse => ()
+              }
+            } catch {
+            | error =>
+              sendProtocolMessage(
+                (Failure({id, message: exceptionMessage(error)}): protocolMessage),
+              )
+            }
+          | Cast(message) =>
+            try {
+              switch handleTransportMessage(Obj.magic(message)) {
+              | Response.RespondLater(promise) =>
+                promise
+                ->Promise.thenResolve(_ => ())
+                ->Promise.catch(_ => Promise.resolve())
+                ->ignore
+              | Response.RespondNow(_) | Response.NoResponse => ()
+              }
+            } catch {
+            | _ => ()
+            }
+          | Success(_) | Failure(_) => ()
           }
         }
 
-        // Store mapping for later removal
-        HandlerMap.set(handlerToWrapped, userResponseHandler, messageHandler)
-
+        HandlerMap.set(handlerToWrapped, userHandler, messageHandler)
         Bindings.OnMessage.addListener(messageHandler)
       }
 
@@ -101,11 +220,9 @@ module Make = (Bindings: RuntimeBindings) => {
       }
   }
 
-  // Utility function to check if extension context is still valid
-  let isContextValid = () => {
-    switch Bindings.getRuntimeId() {
-    | Some(_) => true
-    | None => false // Context invalidated (extension reload/upgrade)
-    }
+  let isContextValid = Bindings.isOpen
+  let close = () => {
+    closeHandler("Runtime closed")
+    Bindings.close()
   }
 }

--- a/src/Runtime.resi
+++ b/src/Runtime.resi
@@ -3,17 +3,19 @@
  * SPDX-License-Identifier: MIT
  */
 
-// Generic Runtime interface for message passing with automatic chunking
-// Users provide their own messaging bindings for different environments
-
 module type RuntimeBindings = {
   type sender
-  let sendMessage: 'a => Promise.t<'b>
+  let requestTimeoutMs: int
+  let postMessage: 'a => result<unit, string>
   module OnMessage: {
-    let addListener: (('a, sender, 'b => unit) => bool) => unit
-    let removeListener: (('a, sender, 'b => unit) => bool) => unit
+    let addListener: (('a, sender) => unit) => unit
+    let removeListener: (('a, sender) => unit) => unit
   }
-  let getRuntimeId: unit => option<string>
+  module OnClose: {
+    let addListener: (string => unit) => unit
+  }
+  let isOpen: unit => bool
+  let close: unit => unit
 }
 
 module Make: (Bindings: RuntimeBindings) =>
@@ -25,4 +27,5 @@ module Make: (Bindings: RuntimeBindings) =>
     let removeListener: ((Types.message<'a>, Bindings.sender) => Response.t<'a>) => unit
   }
   let isContextValid: unit => bool
+  let close: unit => unit
 }

--- a/src/Runtime__test.res
+++ b/src/Runtime__test.res
@@ -1,558 +1,247 @@
-@@warning("-4")
 /*
  * Copyright 2025 BlueHotDog
  * SPDX-License-Identifier: MIT
  */
 
-// Integration tests for Runtime module
-// Testing Response.t to callback conversion and Runtime.Make functor
+type messageListener = (Obj.t, unit) => unit
 
-// Mock bindings for testing
-module MockBindings = {
+let leftMessageListeners: ref<array<messageListener>> = ref([])
+let rightMessageListeners: ref<array<messageListener>> = ref([])
+let leftCloseListeners: ref<array<string => unit>> = ref([])
+let rightCloseListeners: ref<array<string => unit>> = ref([])
+let leftOpen = ref(true)
+let rightOpen = ref(true)
+
+let removeListener = (listeners, listener) => {
+  let removed = ref(false)
+  listeners :=
+    listeners.contents->Array.filter(existing => {
+      if !removed.contents && existing === listener {
+        removed := true
+        false
+      } else {
+        true
+      }
+    })
+}
+
+let closeEndpoints = reason => {
+  if leftOpen.contents || rightOpen.contents {
+    leftOpen := false
+    rightOpen := false
+    leftCloseListeners.contents->Array.forEach(listener => listener(reason))
+    rightCloseListeners.contents->Array.forEach(listener => listener(reason))
+  }
+}
+
+module LeftBindings = {
   type sender = unit
+  let requestTimeoutMs = 30
+  let failNextPost = ref(None)
 
-  // Store sent messages count for verification
-  let sentMessageCount = ref(0)
-
-  // Store added listeners count for verification
-  let addedListenerCount = ref(0)
-  let removedListenerCount = ref(0)
-
-  // Store actual handlers for removeListener testing (using Obj.t for type erasure)
-  let storedHandlers: ref<array<Obj.t>> = ref([])
-
-  let sendMessage: 'a => Promise.t<'b> = message => {
-    // Just increment counter instead of storing the actual messages
-    sentMessageCount := sentMessageCount.contents + 1
-    // Ignore the message for now and return a resolved promise
-    ignore(message)
-    Promise.resolve("mock response"->Obj.magic)
+  let postMessage = message => {
+    switch failNextPost.contents {
+    | Some(error) => {
+        failNextPost := None
+        Error(error)
+      }
+    | None if !leftOpen.contents => Error("Endpoint is closed")
+    | None => {
+        rightMessageListeners.contents->Array.forEach(listener => listener(Obj.magic(message), ()))
+        Ok()
+      }
+    }
   }
 
   module OnMessage = {
-    let addListener: (('a, sender, 'b => unit) => bool) => unit = handler => {
-      addedListenerCount := addedListenerCount.contents + 1
-      storedHandlers := Array.concat(storedHandlers.contents, [Obj.magic(handler)])
+    let addListener = listener => {
+      leftMessageListeners := leftMessageListeners.contents->Array.concat([Obj.magic(listener)])
     }
-
-    let removeListener: (('a, sender, 'b => unit) => bool) => unit = handler => {
-      // Check if handler exists in stored handlers
-      let exists = Array.some(storedHandlers.contents, stored =>
-        Obj.magic(stored) === Obj.magic(handler)
-      )
-      if exists {
-        removedListenerCount := removedListenerCount.contents + 1
-        storedHandlers :=
-          Array.filter(storedHandlers.contents, stored => Obj.magic(stored) !== Obj.magic(handler))
-      }
+    let removeListener = listener => {
+      removeListener(leftMessageListeners, Obj.magic(listener))
     }
   }
 
-  let getRuntimeId = () => Some("mock-runtime-id")
-
-  // Helper to reset mock state
-  let reset = () => {
-    sentMessageCount := 0
-    addedListenerCount := 0
-    removedListenerCount := 0
-    storedHandlers := []
+  module OnClose = {
+    let addListener = listener => {
+      leftCloseListeners := leftCloseListeners.contents->Array.concat([listener])
+    }
   }
+
+  let isOpen = () => leftOpen.contents
+  let close = () => closeEndpoints("Endpoint closed")
 }
 
-// Test message types
+module RightBindings = {
+  type sender = unit
+  let requestTimeoutMs = 30
+
+  let postMessage = message => {
+    if rightOpen.contents {
+      leftMessageListeners.contents->Array.forEach(listener => listener(Obj.magic(message), ()))
+      Ok()
+    } else {
+      Error("Endpoint is closed")
+    }
+  }
+
+  module OnMessage = {
+    let addListener = listener => {
+      rightMessageListeners := rightMessageListeners.contents->Array.concat([Obj.magic(listener)])
+    }
+    let removeListener = listener => {
+      removeListener(rightMessageListeners, Obj.magic(listener))
+    }
+  }
+
+  module OnClose = {
+    let addListener = listener => {
+      rightCloseListeners := rightCloseListeners.contents->Array.concat([listener])
+    }
+  }
+
+  let isOpen = () => rightOpen.contents
+  let close = () => closeEndpoints("Endpoint closed")
+}
+
 type Types.message<_> +=
-  | SimpleTest(string): Types.message<string>
-  | AsyncTest(string): Types.message<string>
-  | NoResponseTest: Types.message<unit>
+  | Echo(string): Types.message<string>
+  | AsyncEcho(string): Types.message<string>
+  | FailNow: Types.message<string>
+  | FailLater: Types.message<string>
+  | NeverRespond: Types.message<string>
+  | Notice(string): Types.message<unit>
 
-// Create Runtime instance with mock bindings
-module TestRuntime = Runtime.Make(MockBindings)
+module LeftRuntime = Runtime.Make(LeftBindings)
+module RightRuntime = Runtime.Make(RightBindings)
 
-// Test: sendMessage passes through to bindings
-let testSendMessagePassthrough = async () => {
-  MockBindings.reset()
+let receivedNotices = ref([])
 
-  let testMessage = SimpleTest("send test")
-  try {
-    let response = await TestRuntime.sendMessage(testMessage)
-
-    let sentCount = MockBindings.sentMessageCount.contents
-    if sentCount === 1 && response === "mock response" {
-      Console.log("PASS: sendMessage passed through to bindings")
-      true
-    } else {
-      Console.error(`FAIL: Expected 1 sent message, got ${sentCount->Int.toString}`)
-      false
-    }
-  } catch {
-  | error =>
-    Console.error2("FAIL: Exception during sendMessage test:", error)
-    false
-  }
-}
-
-// Test: cast (fire-and-forget) works correctly
-let testCastFireAndForget = () => {
-  MockBindings.reset()
-
-  let testMessage = SimpleTest("cast test")
-
-  try {
-    TestRuntime.cast(testMessage)
-
-    let sentCount = MockBindings.sentMessageCount.contents
-    if sentCount === 1 {
-      Console.log("PASS: cast sends message without expecting response")
-      true
-    } else {
-      Console.error(`FAIL: Expected 1 cast message, got ${sentCount->Int.toString}`)
-      false
-    }
-  } catch {
-  | error =>
-    Console.error2("FAIL: Exception during cast test:", error)
-    false
-  }
-}
-
-// Test: addListener converts Response.t to callback pattern
-let testAddListenerConversion = () => {
-  MockBindings.reset()
-
-  let testResponse = "converted response"
-
-  // Create user handler that returns Response.t
-  let userHandler = (message, _sender) => {
+let rightHandler:
+  type response. (Types.message<response>, unit) => Response.t<response> =
+  (message, _sender) => {
     switch message {
-    | SimpleTest(_) => Response.now(testResponse)
-    | AsyncTest(_) => Response.later(Promise.resolve("async response"))
-    | _ => Response.none
-    }
-  }
-
-  try {
-    // Add listener
-    TestRuntime.OnMessage.addListener(userHandler)
-
-    let listenerCount = MockBindings.addedListenerCount.contents
-    if listenerCount === 1 {
-      Console.log("PASS: addListener registered callback with bindings")
-      true
-    } else {
-      Console.error(`FAIL: Expected 1 listener, got ${listenerCount->Int.toString}`)
-      false
-    }
-  } catch {
-  | error =>
-    Console.error2("FAIL: Exception during addListener test:", error)
-    false
-  }
-}
-
-// Test: RespondNow conversion to callback (simplified)
-let testRespondNowConversion = () => {
-  MockBindings.reset()
-
-  let testResponse = "immediate response"
-  let userHandler = (message, _sender) => {
-    switch message {
-    | SimpleTest(_) => Response.now(testResponse)
-    | _ => Response.none
-    }
-  }
-
-  try {
-    TestRuntime.OnMessage.addListener(userHandler)
-    Console.log("PASS: RespondNow handler added without errors")
-    true
-  } catch {
-  | error =>
-    Console.error2("FAIL: Exception during RespondNow test:", error)
-    false
-  }
-}
-
-// Test: RespondLater conversion to callback with async (simplified)
-let testRespondLaterConversion = () => {
-  MockBindings.reset()
-
-  let asyncResponse = "async response"
-  let userHandler = (message, _sender) => {
-    switch message {
-    | AsyncTest(_) => Response.later(Promise.resolve(asyncResponse))
-    | _ => Response.none
-    }
-  }
-
-  try {
-    TestRuntime.OnMessage.addListener(userHandler)
-    Console.log("PASS: RespondLater handler added without errors")
-    true
-  } catch {
-  | error =>
-    Console.error2("FAIL: Exception during RespondLater test:", error)
-    false
-  }
-}
-
-// Test: NoResponse conversion to callback (simplified)
-let testNoResponseConversion = () => {
-  MockBindings.reset()
-
-  // Create a separate handler specifically for unit response messages
-  let unitHandler = (message, _sender) => {
-    switch message {
-    | NoResponseTest => Response.none
-    | _ => Response.none
-    }
-  }
-
-  try {
-    TestRuntime.OnMessage.addListener(unitHandler)
-    Console.log("PASS: NoResponse handler added without errors")
-    true
-  } catch {
-  | error =>
-    Console.error2("FAIL: Exception during NoResponse test:", error)
-    false
-  }
-}
-
-// Test: isContextValid utility
-let testIsContextValid = () => {
-  try {
-    let isValid = TestRuntime.isContextValid()
-
-    if isValid {
-      Console.log("PASS: isContextValid returns true with mock runtime ID")
-      true
-    } else {
-      Console.error("FAIL: isContextValid should return true with mock runtime ID")
-      false
-    }
-  } catch {
-  | error =>
-    Console.error2("FAIL: Exception during isContextValid test:", error)
-    false
-  }
-}
-
-// Test: Error handling in user handler (simplified)
-let testErrorHandlingInUserHandler = () => {
-  MockBindings.reset()
-
-  let userHandler = (_message, _sender) => {
-    // Simulate error in user handler
-    JsError.throwWithMessage("Test error in user handler")
-  }
-
-  try {
-    TestRuntime.OnMessage.addListener(userHandler)
-    Console.log("PASS: Error handler added without immediate crash")
-    true
-  } catch {
-  | error =>
-    Console.error2("PASS: Error in user handler was caught during setup", error)
-    true
-  }
-}
-
-// Test: Chunked message handling with out-of-order responses
-let testChunkedMessage = async () => {
-  MockBindings.reset()
-
-  try {
-    let largeMessage = "A"->String.repeat(MessageChunker.defaultChunkSize + 1000)
-    let testMessage = SimpleTest(largeMessage)
-    let response = await TestRuntime.sendMessage(testMessage)
-
-    if MockBindings.sentMessageCount.contents > 1 && response === "mock response" {
-      Console.log("PASS: Chunked message handled")
-      true
-    } else {
-      Console.error("FAIL: Chunked message did not send all chunks or return the final response")
-      false
-    }
-  } catch {
-  | error =>
-    Console.error2("FAIL: Exception during chunked message test:", error)
-    false
-  }
-}
-
-// Test: Basic chunked message handling
-let testBasicChunkedMessage = async () => {
-  MockBindings.reset()
-
-  try {
-    let largeMessage = "B"->String.repeat(MessageChunker.defaultChunkSize + 1000)
-    let testMessage = SimpleTest(largeMessage)
-
-    let response = await TestRuntime.sendMessage(testMessage)
-    if response === "mock response" {
-      Console.log("PASS: Large message handled (basic chunking)")
-      true
-    } else {
-      Console.error("FAIL: Large message returned the wrong response")
-      false
-    }
-  } catch {
-  | error =>
-    Console.error2("FAIL: Exception during basic chunked test:", error)
-    false
-  }
-}
-
-// Test: removeListener removes correct handler
-let testRemoveListenerBasic = () => {
-  MockBindings.reset()
-
-  let handler1 = (message, _sender) => {
-    switch message {
-    | SimpleTest(_) => Response.now("handler1")
-    | _ => Response.none
-    }
-  }
-
-  let handler2 = (message, _sender) => {
-    switch message {
-    | SimpleTest(_) => Response.now("handler2")
-    | _ => Response.none
-    }
-  }
-
-  try {
-    // Add both handlers
-    TestRuntime.OnMessage.addListener(handler1)
-    TestRuntime.OnMessage.addListener(handler2)
-
-    // Verify both added
-    let addedCount = MockBindings.addedListenerCount.contents
-    if addedCount !== 2 {
-      Console.error(`FAIL: Expected 2 added listeners, got ${addedCount->Int.toString}`)
-      false
-    } else {
-      // Remove first handler
-      TestRuntime.OnMessage.removeListener(handler1)
-
-      let removedCount = MockBindings.removedListenerCount.contents
-      if removedCount === 1 {
-        Console.log("PASS: removeListener removed correct handler")
-        true
-      } else {
-        Console.error(`FAIL: Expected 1 removed listener, got ${removedCount->Int.toString}`)
-        false
+    | Echo(value) => Response.now(value)
+    | AsyncEcho(value) => Response.later(Promise.resolve(value))
+    | FailNow => JsError.throwWithMessage("Immediate handler failure")
+    | FailLater =>
+      Response.later(
+        Promise.make((_resolve, reject) => {
+          reject(JsError.make("Deferred handler failure"))
+        }),
+      )
+    | NeverRespond => Response.none
+    | Notice(value) => {
+        receivedNotices := receivedNotices.contents->Array.concat([value])
+        Response.none
       }
-    }
-  } catch {
-  | error =>
-    Console.error2("FAIL: Exception during removeListener basic test:", error)
-    false
-  }
-}
-
-// Test: removeListener with non-existent handler
-let testRemoveListenerNonExistent = () => {
-  MockBindings.reset()
-
-  let handler1 = (message, _sender) => {
-    switch message {
-    | SimpleTest(_) => Response.now("handler1")
     | _ => Response.none
     }
   }
 
-  let handler2 = (message, _sender) => {
-    switch message {
-    | SimpleTest(_) => Response.now("handler2")
-    | _ => Response.none
-    }
-  }
+RightRuntime.OnMessage.addListener(rightHandler)
+LeftRuntime.OnMessage.addListener(rightHandler)
 
+@val external errorToString: 'a => string = "String"
+
+let expectRejection = async (promise, expectedMessage) => {
   try {
-    // Add only handler1
-    TestRuntime.OnMessage.addListener(handler1)
-
-    // Try to remove handler2 (never added)
-    TestRuntime.OnMessage.removeListener(handler2)
-
-    let removedCount = MockBindings.removedListenerCount.contents
-    if removedCount === 0 {
-      Console.log("PASS: removeListener ignores non-existent handler")
-      true
-    } else {
-      Console.error(`FAIL: Expected 0 removed listeners, got ${removedCount->Int.toString}`)
-      false
-    }
+    (await promise)->ignore
+    false
   } catch {
   | error =>
-    Console.error2("FAIL: Exception during removeListener non-existent test:", error)
-    false
+    error
+    ->JsExn.fromException
+    ->Option.flatMap(JsExn.message)
+    ->Option.getOr(errorToString(error))
+    ->String.includes(expectedMessage)
   }
 }
 
-// Test: removeListener with same handler added multiple times
-let testRemoveListenerDuplicate = () => {
-  MockBindings.reset()
+let testRoundTrip = async () => {
+  let response = await LeftRuntime.sendMessage(Echo("hello"))
+  response === "hello"
+}
 
+let testAsyncRoundTrip = async () => {
+  let response = await LeftRuntime.sendMessage(AsyncEcho("later"))
+  response === "later"
+}
+
+let testReverseRoundTrip = async () => {
+  let response = await RightRuntime.sendMessage(Echo("reverse"))
+  response === "reverse"
+}
+
+let testCast = () => {
+  LeftRuntime.cast(Notice("received"))
+  receivedNotices.contents->Array.some(value => value === "received")
+}
+
+let testImmediateRemoteError = async () => {
+  await expectRejection(LeftRuntime.sendMessage(FailNow), "Immediate handler failure")
+}
+
+let testDeferredRemoteError = async () => {
+  await expectRejection(LeftRuntime.sendMessage(FailLater), "Deferred handler failure")
+}
+
+let testTimeout = async () => {
+  await expectRejection(LeftRuntime.sendMessage(NeverRespond), "Request timed out")
+}
+
+let testPostFailure = async () => {
+  LeftBindings.failNextPost := Some("Structured clone failed")
+  await expectRejection(LeftRuntime.sendMessage(Echo("uncloneable")), "Structured clone failed")
+}
+
+let testChunkedRoundTrip = async () => {
+  let value = "A"->String.repeat(MessageChunker.defaultChunkSize + 1000)
+  let response = await LeftRuntime.sendMessage(Echo(value))
+  response === value
+}
+
+let testListenerRemoval = () => {
   let handler = (message, _sender) => {
     switch message {
-    | SimpleTest(_) => Response.now("handler")
+    | Echo(value) => Response.now(value)
     | _ => Response.none
     }
   }
-
-  try {
-    // Add same handler twice
-    TestRuntime.OnMessage.addListener(handler)
-    TestRuntime.OnMessage.addListener(handler)
-
-    let addedCount = MockBindings.addedListenerCount.contents
-    if addedCount !== 2 {
-      Console.error(`FAIL: Expected 2 added listeners, got ${addedCount->Int.toString}`)
-      false
-    } else {
-      // Remove handler once
-      TestRuntime.OnMessage.removeListener(handler)
-
-      let removedCount = MockBindings.removedListenerCount.contents
-      let remainingHandlers = Array.length(MockBindings.storedHandlers.contents)
-
-      if removedCount === 1 && remainingHandlers === 1 {
-        Console.log("PASS: removeListener removes one instance of duplicate handler")
-        true
-      } else {
-        Console.error(
-          `FAIL: Expected 1 removed, 1 remaining. Got ${removedCount->Int.toString} removed, ${remainingHandlers->Int.toString} remaining`,
-        )
-        false
-      }
-    }
-  } catch {
-  | error =>
-    Console.error2("FAIL: Exception during removeListener duplicate test:", error)
-    false
-  }
+  let before = leftMessageListeners.contents->Array.length
+  LeftRuntime.OnMessage.addListener(handler)
+  LeftRuntime.OnMessage.removeListener(handler)
+  leftMessageListeners.contents->Array.length === before
 }
 
-// Test: removeListener with different message types
-let testRemoveListenerDifferentTypes = () => {
-  MockBindings.reset()
+let testContextValidity = () => LeftRuntime.isContextValid()
 
-  let stringHandler = (message, _sender) => {
-    switch message {
-    | SimpleTest(_) => Response.now("string response")
-    | _ => Response.none
-    }
-  }
-
-  let unitHandler = (message, _sender) => {
-    switch message {
-    | NoResponseTest => Response.none
-    | _ => Response.none
-    }
-  }
-
-  try {
-    // Add handlers with different message types
-    TestRuntime.OnMessage.addListener(stringHandler)
-    TestRuntime.OnMessage.addListener(unitHandler)
-
-    let addedCount = MockBindings.addedListenerCount.contents
-    if addedCount !== 2 {
-      Console.error(`FAIL: Expected 2 added listeners, got ${addedCount->Int.toString}`)
-      false
-    } else {
-      // Remove string handler
-      TestRuntime.OnMessage.removeListener(stringHandler)
-
-      let removedCount = MockBindings.removedListenerCount.contents
-      let remainingHandlers = Array.length(MockBindings.storedHandlers.contents)
-
-      if removedCount === 1 && remainingHandlers === 1 {
-        Console.log("PASS: removeListener works with different message types")
-        true
-      } else {
-        Console.error(
-          `FAIL: Expected 1 removed, 1 remaining. Got ${removedCount->Int.toString} removed, ${remainingHandlers->Int.toString} remaining`,
-        )
-        false
-      }
-    }
-  } catch {
-  | error =>
-    Console.error2("FAIL: Exception during removeListener different types test:", error)
-    false
-  }
+let testCloseRejectsPending = async () => {
+  let pending = LeftRuntime.sendMessage(NeverRespond)
+  LeftRuntime.close()
+  let rejected = await expectRejection(pending, "Runtime closed")
+  rejected && !LeftRuntime.isContextValid() && !RightRuntime.isContextValid()
 }
 
-// Test: removeListener memory behavior (WeakMap cleanup)
-let testRemoveListenerMemoryBehavior = () => {
-  MockBindings.reset()
-
-  // Create handler in a scope that will be GC eligible
-  let testHandler = ref(None)
-
-  let createHandler = () => {
-    (message, _sender) => {
-      switch message {
-      | SimpleTest(_) => Response.now("scoped handler")
-      | _ => Response.none
-      }
-    }
-  }
-
-  try {
-    let handler = createHandler()
-    testHandler := Some(handler)
-
-    // Add and then remove handler
-    TestRuntime.OnMessage.addListener(handler)
-    TestRuntime.OnMessage.removeListener(handler)
-
-    let removedCount = MockBindings.removedListenerCount.contents
-    if removedCount === 1 {
-      // Clear reference to make handler eligible for GC
-      testHandler := None
-
-      Console.log("PASS: removeListener completed cleanup (WeakMap should allow GC)")
-      true
-    } else {
-      Console.error(`FAIL: Expected 1 removed listener, got ${removedCount->Int.toString}`)
-      false
-    }
-  } catch {
-  | error =>
-    Console.error2("FAIL: Exception during removeListener memory test:", error)
-    false
-  }
-}
-
-// Run all tests
 let runTests = async () => {
   let syncTests = [
-    ("cast fire-and-forget", testCastFireAndForget),
-    ("addListener conversion", testAddListenerConversion),
-    ("RespondNow conversion", testRespondNowConversion),
-    ("RespondLater conversion", testRespondLaterConversion),
-    ("NoResponse conversion", testNoResponseConversion),
-    ("isContextValid utility", testIsContextValid),
-    ("Error handling in user handler", testErrorHandlingInUserHandler),
-    ("removeListener basic functionality", testRemoveListenerBasic),
-    ("removeListener non-existent handler", testRemoveListenerNonExistent),
-    ("removeListener duplicate handler", testRemoveListenerDuplicate),
-    ("removeListener different message types", testRemoveListenerDifferentTypes),
-    ("removeListener memory behavior", testRemoveListenerMemoryBehavior),
+    ("typed fire-and-forget cast", testCast),
+    ("listener removal", testListenerRemoval),
+    ("context validity", testContextValidity),
   ]
-
   let asyncTests = [
-    ("sendMessage passthrough", testSendMessagePassthrough),
-    ("Chunked message handling", testChunkedMessage),
-    ("Basic chunked message", testBasicChunkedMessage),
+    ("typed request round trip", testRoundTrip),
+    ("reverse request round trip", testReverseRoundTrip),
+    ("deferred response round trip", testAsyncRoundTrip),
+    ("immediate remote error", testImmediateRemoteError),
+    ("deferred remote error", testDeferredRemoteError),
+    ("request timeout", testTimeout),
+    ("structured clone failure", testPostFailure),
+    ("chunked request round trip", testChunkedRoundTrip),
+    ("close rejects pending requests", testCloseRejectsPending),
   ]
 
   await TestUtils.runMixedTests("Runtime Integration Tests", syncTests, asyncTests)
 }
 
-// Export for running
 let main = runTests

--- a/src/WindowTransport.res
+++ b/src/WindowTransport.res
@@ -1,0 +1,446 @@
+/*
+ * Copyright 2025 BlueHotDog
+ * SPDX-License-Identifier: MIT
+ */
+
+type browserWindow
+type messagePort
+type messageChannel
+type messageEvent
+
+@new external makeMessageChannel: unit => messageChannel = "MessageChannel"
+@get external firstPort: messageChannel => messagePort = "port1"
+@get external secondPort: messageChannel => messagePort = "port2"
+@send external startPort: messagePort => unit = "start"
+@send external closePort: messagePort => unit = "close"
+@send external postPortMessage: (messagePort, 'a) => unit = "postMessage"
+@send
+external postWindowMessage: (browserWindow, 'a, string, array<messagePort>) => unit = "postMessage"
+@send
+external addWindowEventListener: (browserWindow, string, 'event => unit) => unit =
+  "addEventListener"
+@send
+external removeWindowEventListener: (browserWindow, string, 'event => unit) => unit =
+  "removeEventListener"
+@send
+external addPortEventListener: (messagePort, string, 'event => unit) => unit = "addEventListener"
+@get external eventData: messageEvent => Obj.t = "data"
+@get external eventOrigin: messageEvent => string = "origin"
+@get external eventSource: messageEvent => browserWindow = "source"
+@get external eventPorts: messageEvent => array<messagePort> = "ports"
+@val external currentWindow: browserWindow = "window"
+
+let marker = "@bluehotdog/reworker/window/v1"
+
+type bootstrapMessage = {
+  marker: string,
+  kind: string,
+  connectionId: Id.t,
+}
+
+type portMessage = {
+  marker: string,
+  kind: string,
+  connectionId: Id.t,
+  payload: option<Obj.t>,
+  reason: option<string>,
+}
+
+type messageListener = (Obj.t, unit) => unit
+
+type connection = {
+  port: messagePort,
+  id: Id.t,
+  mutable ready: bool,
+}
+
+type endpoint = {
+  mutable connection: option<connection>,
+  messageListeners: ref<array<messageListener>>,
+  closeListeners: ref<array<string => unit>>,
+}
+
+let makeEndpoint = () => {
+  connection: None,
+  messageListeners: ref([]),
+  closeListeners: ref([]),
+}
+
+let removeFirst = (listeners, listener) => {
+  let removed = ref(false)
+  listeners :=
+    listeners.contents->Array.filter(existing => {
+      if !removed.contents && existing === listener {
+        removed := true
+        false
+      } else {
+        true
+      }
+    })
+}
+
+let makePortMessage = (~kind, ~connectionId, ~payload=None, ~reason=None) => {
+  marker,
+  kind,
+  connectionId,
+  payload,
+  reason,
+}
+
+let readPortMessage = value => {
+  try {
+    let message: portMessage = Obj.magic(value)
+    message.marker === marker ? Some(message) : None
+  } catch {
+  | _ => None
+  }
+}
+
+let notifyClosed = (endpoint, reason) => {
+  endpoint.closeListeners.contents->Array.forEach(listener => listener(reason))
+}
+
+let disconnect = (endpoint, reason, ~notifyRemote) => {
+  switch endpoint.connection {
+  | None => ()
+  | Some(connection) => {
+      endpoint.connection = None
+      if notifyRemote {
+        try {
+          postPortMessage(
+            connection.port,
+            makePortMessage(~kind="close", ~connectionId=connection.id, ~reason=Some(reason)),
+          )
+        } catch {
+        | _ => ()
+        }
+      }
+      closePort(connection.port)
+      notifyClosed(endpoint, reason)
+    }
+  }
+}
+
+let isCurrentConnection = (endpoint, connection) => {
+  switch endpoint.connection {
+  | Some(current) => current === connection
+  | None => false
+  }
+}
+
+let activate = (endpoint, port, id, ~ready, ~onReady) => {
+  let connection = {port, id, ready}
+  endpoint.connection = Some(connection)
+
+  let onMessage = event => {
+    if isCurrentConnection(endpoint, connection) {
+      switch readPortMessage(eventData(event)) {
+      | Some(message) if message.connectionId === id =>
+        switch message.kind {
+        | "ready" => onReady()
+        | "data" if connection.ready =>
+          switch message.payload {
+          | Some(payload) =>
+            endpoint.messageListeners.contents->Array.forEach(listener => listener(payload, ()))
+          | None => disconnect(endpoint, "Received an invalid port message", ~notifyRemote=true)
+          }
+        | "close" =>
+          disconnect(
+            endpoint,
+            message.reason->Option.getOr("Remote endpoint closed"),
+            ~notifyRemote=false,
+          )
+        | _ => ()
+        }
+      | Some(_) => ()
+      | None => disconnect(endpoint, "Received an invalid port message", ~notifyRemote=true)
+      }
+    }
+  }
+  let onMessageError = _event => {
+    if isCurrentConnection(endpoint, connection) {
+      disconnect(endpoint, "Message port could not deserialize a value", ~notifyRemote=true)
+    }
+  }
+
+  addPortEventListener(port, "message", onMessage)
+  addPortEventListener(port, "messageerror", onMessageError)
+  startPort(port)
+}
+
+let markReady = endpoint => {
+  switch endpoint.connection {
+  | Some(connection) => connection.ready = true
+  | None => ()
+  }
+}
+
+let post = (endpoint, message) => {
+  switch endpoint.connection {
+  | Some(connection) if connection.ready =>
+    try {
+      postPortMessage(
+        connection.port,
+        makePortMessage(
+          ~kind="data",
+          ~connectionId=connection.id,
+          ~payload=Some(Obj.magic(message)),
+        ),
+      )
+      Ok()
+    } catch {
+    | error =>
+      Error(
+        error
+        ->JsExn.fromException
+        ->Option.flatMap(JsExn.message)
+        ->Option.getOr("Message could not be cloned"),
+      )
+    }
+  | Some(_) => Error("Window transport is not ready")
+  | None => Error("Window transport is closed")
+  }
+}
+
+let isOpen = endpoint => {
+  switch endpoint.connection {
+  | Some(connection) => connection.ready
+  | None => false
+  }
+}
+
+module Parent = {
+  module Make = (
+    Config: {
+      type targetWindow
+      type loadEvent
+      let targetOrigin: string
+      let targetWindow: unit => targetWindow
+      let addLoadListener: (loadEvent => unit) => unit
+      let removeLoadListener: (loadEvent => unit) => unit
+      let requestTimeoutMs: int
+    },
+  ) => {
+    type sender = unit
+
+    type connectionAttempt = {
+      id: Id.t,
+      resolve: unit => unit,
+      reject: JsError.t => unit,
+      timeoutId: timeoutId,
+    }
+
+    let requestTimeoutMs = Config.requestTimeoutMs
+    let endpoint = makeEndpoint()
+    let attempt: ref<option<connectionAttempt>> = ref(None)
+    let listeningForLoads = ref(false)
+    let reconnect = ref(() => ())
+
+    let rejectAttempt = reason => {
+      switch attempt.contents {
+      | Some(current) => {
+          clearTimeout(current.timeoutId)
+          attempt := None
+          current.reject(JsError.make(reason))
+        }
+      | None => ()
+      }
+    }
+
+    endpoint.closeListeners := endpoint.closeListeners.contents->Array.concat([rejectAttempt])
+
+    let closeConnection = reason => {
+      rejectAttempt(reason)
+      disconnect(endpoint, reason, ~notifyRemote=true)
+    }
+
+    let loadHandler = _event => reconnect.contents()
+
+    let rejectPromise = message => {
+      Promise.make((_resolve, reject) => reject(JsError.make(message)))
+    }
+
+    let connect = () => {
+      if Config.targetOrigin === "" || Config.targetOrigin === "*" {
+        rejectPromise("targetOrigin must be an explicit origin")
+      } else {
+        if !listeningForLoads.contents {
+          listeningForLoads := true
+          Config.addLoadListener(loadHandler)
+        }
+        closeConnection("Iframe navigation replaced the connection")
+
+        let targetWindow = Config.targetWindow()
+        let id = Id.make()
+        let channel = makeMessageChannel()
+        let port = firstPort(channel)
+        Promise.make((resolve, reject) => {
+          let timeoutId = setTimeout(() => {
+            rejectAttempt("Window transport readiness timed out")
+            disconnect(endpoint, "Window transport readiness timed out", ~notifyRemote=true)
+          }, Config.requestTimeoutMs)
+          attempt := Some({id, resolve, reject, timeoutId})
+
+          activate(endpoint, port, id, ~ready=false, ~onReady=() => {
+            switch attempt.contents {
+            | Some(current) if current.id === id => {
+                clearTimeout(current.timeoutId)
+                attempt := None
+                markReady(endpoint)
+                current.resolve()
+              }
+            | Some(_) | None => ()
+            }
+          })
+
+          try {
+            let bootstrap = {marker, kind: "connect", connectionId: id}
+            postWindowMessage(
+              Obj.magic(targetWindow),
+              bootstrap,
+              Config.targetOrigin,
+              [secondPort(channel)],
+            )
+          } catch {
+          | error => {
+              let reason =
+                error
+                ->JsExn.fromException
+                ->Option.flatMap(JsExn.message)
+                ->Option.getOr("Failed to transfer the message port")
+              rejectAttempt(reason)
+              disconnect(endpoint, reason, ~notifyRemote=false)
+            }
+          }
+        })
+      }
+    }
+
+    reconnect :=
+      (
+        () => {
+          closeConnection("Iframe reloaded")
+          connect()->Promise.catch(_ => Promise.resolve())->ignore
+        }
+      )
+
+    let postMessage = message => post(endpoint, message)
+
+    module OnMessage = {
+      let addListener = listener => {
+        endpoint.messageListeners :=
+          endpoint.messageListeners.contents->Array.concat([Obj.magic(listener)])
+      }
+      let removeListener = listener => {
+        removeFirst(endpoint.messageListeners, Obj.magic(listener))
+      }
+    }
+
+    module OnClose = {
+      let addListener = listener => {
+        endpoint.closeListeners := endpoint.closeListeners.contents->Array.concat([listener])
+      }
+    }
+
+    let isOpen = () => isOpen(endpoint)
+
+    let close = () => {
+      if listeningForLoads.contents {
+        listeningForLoads := false
+        Config.removeLoadListener(loadHandler)
+      }
+      closeConnection("Window transport closed")
+    }
+  }
+}
+
+module Child = {
+  module Make = (
+    Config: {
+      type parentWindow
+      let parentWindow: parentWindow
+      let parentOrigin: string
+      let requestTimeoutMs: int
+    },
+  ) => {
+    type sender = unit
+
+    let requestTimeoutMs = Config.requestTimeoutMs
+    let endpoint = makeEndpoint()
+    let listening = ref(false)
+
+    let onBootstrapMessage = event => {
+      let sourceMatches = eventSource(event) === Obj.magic(Config.parentWindow)
+
+      if eventOrigin(event) === Config.parentOrigin && sourceMatches {
+        try {
+          let bootstrap: bootstrapMessage = Obj.magic(eventData(event))
+          if bootstrap.marker === marker && bootstrap.kind === "connect" {
+            switch eventPorts(event)->Array.get(0) {
+            | Some(port) => {
+                disconnect(endpoint, "Parent replaced the connection", ~notifyRemote=false)
+                activate(endpoint, port, bootstrap.connectionId, ~ready=true, ~onReady=() => ())
+                try {
+                  postPortMessage(
+                    port,
+                    makePortMessage(~kind="ready", ~connectionId=bootstrap.connectionId),
+                  )
+                } catch {
+                | _ =>
+                  disconnect(
+                    endpoint,
+                    "Failed to confirm window transport readiness",
+                    ~notifyRemote=true,
+                  )
+                }
+              }
+            | None => ()
+            }
+          }
+        } catch {
+        | _ => ()
+        }
+      }
+    }
+
+    let listen = () => {
+      if Config.parentOrigin === "" || Config.parentOrigin === "*" {
+        Error("parentOrigin must be an explicit origin")
+      } else if listening.contents {
+        Ok()
+      } else {
+        listening := true
+        addWindowEventListener(currentWindow, "message", onBootstrapMessage)
+        Ok()
+      }
+    }
+
+    let postMessage = message => post(endpoint, message)
+
+    module OnMessage = {
+      let addListener = listener => {
+        endpoint.messageListeners :=
+          endpoint.messageListeners.contents->Array.concat([Obj.magic(listener)])
+      }
+      let removeListener = listener => {
+        removeFirst(endpoint.messageListeners, Obj.magic(listener))
+      }
+    }
+
+    module OnClose = {
+      let addListener = listener => {
+        endpoint.closeListeners := endpoint.closeListeners.contents->Array.concat([listener])
+      }
+    }
+
+    let isOpen = () => isOpen(endpoint)
+
+    let close = () => {
+      if listening.contents {
+        listening := false
+        removeWindowEventListener(currentWindow, "message", onBootstrapMessage)
+      }
+      disconnect(endpoint, "Window transport closed", ~notifyRemote=true)
+    }
+  }
+}

--- a/src/WindowTransport.res
+++ b/src/WindowTransport.res
@@ -3,33 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-type browserWindow
-type messagePort
-type messageChannel
-type messageEvent
-
-@new external makeMessageChannel: unit => messageChannel = "MessageChannel"
-@get external firstPort: messageChannel => messagePort = "port1"
-@get external secondPort: messageChannel => messagePort = "port2"
-@send external startPort: messagePort => unit = "start"
-@send external closePort: messagePort => unit = "close"
-@send external postPortMessage: (messagePort, 'a) => unit = "postMessage"
-@send
-external postWindowMessage: (browserWindow, 'a, string, array<messagePort>) => unit = "postMessage"
-@send
-external addWindowEventListener: (browserWindow, string, 'event => unit) => unit =
-  "addEventListener"
-@send
-external removeWindowEventListener: (browserWindow, string, 'event => unit) => unit =
-  "removeEventListener"
-@send
-external addPortEventListener: (messagePort, string, 'event => unit) => unit = "addEventListener"
-@get external eventData: messageEvent => Obj.t = "data"
-@get external eventOrigin: messageEvent => string = "origin"
-@get external eventSource: messageEvent => browserWindow = "source"
-@get external eventPorts: messageEvent => array<messagePort> = "ports"
-@val external currentWindow: browserWindow = "window"
-
 let marker = "@bluehotdog/reworker/window/v1"
 
 type bootstrapMessage = {
@@ -49,7 +22,7 @@ type portMessage = {
 type messageListener = (Obj.t, unit) => unit
 
 type connection = {
-  port: messagePort,
+  port: MessagePort.t,
   id: Id.t,
   mutable ready: bool,
 }
@@ -107,7 +80,7 @@ let disconnect = (endpoint, reason, ~notifyRemote) => {
       endpoint.connection = None
       if notifyRemote {
         try {
-          postPortMessage(
+          MessagePort.postMessage(
             connection.port,
             makePortMessage(~kind="close", ~connectionId=connection.id, ~reason=Some(reason)),
           )
@@ -115,7 +88,7 @@ let disconnect = (endpoint, reason, ~notifyRemote) => {
         | _ => ()
         }
       }
-      closePort(connection.port)
+      MessagePort.close(connection.port)
       notifyClosed(endpoint, reason)
     }
   }
@@ -134,7 +107,7 @@ let activate = (endpoint, port, id, ~ready, ~onReady) => {
 
   let onMessage = event => {
     if isCurrentConnection(endpoint, connection) {
-      switch readPortMessage(eventData(event)) {
+      switch readPortMessage(MessageEvent.data(event)) {
       | Some(message) if message.connectionId === id =>
         switch message.kind {
         | "ready" => onReady()
@@ -163,9 +136,9 @@ let activate = (endpoint, port, id, ~ready, ~onReady) => {
     }
   }
 
-  addPortEventListener(port, "message", onMessage)
-  addPortEventListener(port, "messageerror", onMessageError)
-  startPort(port)
+  MessagePort.addEventListener(port, "message", onMessage)
+  MessagePort.addEventListener(port, "messageerror", onMessageError)
+  MessagePort.start(port)
 }
 
 let markReady = endpoint => {
@@ -179,7 +152,7 @@ let post = (endpoint, message) => {
   switch endpoint.connection {
   | Some(connection) if connection.ready =>
     try {
-      postPortMessage(
+      MessagePort.postMessage(
         connection.port,
         makePortMessage(
           ~kind="data",
@@ -272,8 +245,8 @@ module Parent = {
 
         let targetWindow = Config.targetWindow()
         let id = Id.make()
-        let channel = makeMessageChannel()
-        let port = firstPort(channel)
+        let channel = MessageChannel.make()
+        let port = MessageChannel.port1(channel)
         Promise.make((resolve, reject) => {
           let timeoutId = setTimeout(() => {
             rejectAttempt("Window transport readiness timed out")
@@ -295,11 +268,11 @@ module Parent = {
 
           try {
             let bootstrap = {marker, kind: "connect", connectionId: id}
-            postWindowMessage(
+            BrowserWindow.postMessage(
               Obj.magic(targetWindow),
               bootstrap,
               Config.targetOrigin,
-              [secondPort(channel)],
+              [MessageChannel.port2(channel)],
             )
           } catch {
           | error => {
@@ -370,18 +343,18 @@ module Child = {
     let listening = ref(false)
 
     let onBootstrapMessage = event => {
-      let sourceMatches = eventSource(event) === Obj.magic(Config.parentWindow)
+      let sourceMatches = MessageEvent.source(event) === Obj.magic(Config.parentWindow)
 
-      if eventOrigin(event) === Config.parentOrigin && sourceMatches {
+      if MessageEvent.origin(event) === Config.parentOrigin && sourceMatches {
         try {
-          let bootstrap: bootstrapMessage = Obj.magic(eventData(event))
+          let bootstrap: bootstrapMessage = Obj.magic(MessageEvent.data(event))
           if bootstrap.marker === marker && bootstrap.kind === "connect" {
-            switch eventPorts(event)->Array.get(0) {
+            switch MessageEvent.ports(event)->Array.get(0) {
             | Some(port) => {
                 disconnect(endpoint, "Parent replaced the connection", ~notifyRemote=false)
                 activate(endpoint, port, bootstrap.connectionId, ~ready=true, ~onReady=() => ())
                 try {
-                  postPortMessage(
+                  MessagePort.postMessage(
                     port,
                     makePortMessage(~kind="ready", ~connectionId=bootstrap.connectionId),
                   )
@@ -410,7 +383,7 @@ module Child = {
         Ok()
       } else {
         listening := true
-        addWindowEventListener(currentWindow, "message", onBootstrapMessage)
+        BrowserWindow.addEventListener(BrowserWindow.current, "message", onBootstrapMessage)
         Ok()
       }
     }
@@ -438,7 +411,7 @@ module Child = {
     let close = () => {
       if listening.contents {
         listening := false
-        removeWindowEventListener(currentWindow, "message", onBootstrapMessage)
+        BrowserWindow.removeEventListener(BrowserWindow.current, "message", onBootstrapMessage)
       }
       disconnect(endpoint, "Window transport closed", ~notifyRemote=true)
     }

--- a/src/WindowTransport.resi
+++ b/src/WindowTransport.resi
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 BlueHotDog
+ * SPDX-License-Identifier: MIT
+ */
+
+module Parent: {
+  module Make: (
+    Config: {
+      type targetWindow
+      type loadEvent
+      let targetOrigin: string
+      let targetWindow: unit => targetWindow
+      let addLoadListener: (loadEvent => unit) => unit
+      let removeLoadListener: (loadEvent => unit) => unit
+      let requestTimeoutMs: int
+    },
+  ) =>
+  {
+    type sender = unit
+    let requestTimeoutMs: int
+    let postMessage: 'a => result<unit, string>
+    module OnMessage: {
+      let addListener: (('a, sender) => unit) => unit
+      let removeListener: (('a, sender) => unit) => unit
+    }
+    module OnClose: {
+      let addListener: (string => unit) => unit
+    }
+    let isOpen: unit => bool
+    let close: unit => unit
+    let connect: unit => promise<unit>
+  }
+}
+
+module Child: {
+  module Make: (
+    Config: {
+      type parentWindow
+      let parentWindow: parentWindow
+      let parentOrigin: string
+      let requestTimeoutMs: int
+    },
+  ) =>
+  {
+    type sender = unit
+    let requestTimeoutMs: int
+    let postMessage: 'a => result<unit, string>
+    module OnMessage: {
+      let addListener: (('a, sender) => unit) => unit
+      let removeListener: (('a, sender) => unit) => unit
+    }
+    module OnClose: {
+      let addListener: (string => unit) => unit
+    }
+    let isOpen: unit => bool
+    let close: unit => unit
+    let listen: unit => result<unit, string>
+  }
+}

--- a/src/WindowTransport.resi
+++ b/src/WindowTransport.resi
@@ -16,18 +16,7 @@ module Parent: {
     },
   ) =>
   {
-    type sender = unit
-    let requestTimeoutMs: int
-    let postMessage: 'a => result<unit, string>
-    module OnMessage: {
-      let addListener: (('a, sender) => unit) => unit
-      let removeListener: (('a, sender) => unit) => unit
-    }
-    module OnClose: {
-      let addListener: (string => unit) => unit
-    }
-    let isOpen: unit => bool
-    let close: unit => unit
+    include Runtime.RuntimeBindings with type sender = unit
     let connect: unit => promise<unit>
   }
 }
@@ -42,18 +31,7 @@ module Child: {
     },
   ) =>
   {
-    type sender = unit
-    let requestTimeoutMs: int
-    let postMessage: 'a => result<unit, string>
-    module OnMessage: {
-      let addListener: (('a, sender) => unit) => unit
-      let removeListener: (('a, sender) => unit) => unit
-    }
-    module OnClose: {
-      let addListener: (string => unit) => unit
-    }
-    let isOpen: unit => bool
-    let close: unit => unit
+    include Runtime.RuntimeBindings with type sender = unit
     let listen: unit => result<unit, string>
   }
 }

--- a/src/WindowTransportBrowserMessages__test.res
+++ b/src/WindowTransportBrowserMessages__test.res
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2025 BlueHotDog
+ * SPDX-License-Identifier: MIT
+ */
+
+type Types.message<_> +=
+  | Ping(string): Types.message<string>
+  | Reverse(string): Types.message<string>
+  | AskReverse(string): Types.message<string>
+  | Notice(string): Types.message<unit>
+  | GetNotice: Types.message<option<string>>
+  | Fail: Types.message<string>
+  | Never: Types.message<string>
+  | Uncloneable(Obj.t): Types.message<string>

--- a/src/WindowTransportChild__test.res
+++ b/src/WindowTransportChild__test.res
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 BlueHotDog
+ * SPDX-License-Identifier: MIT
+ */
+
+type browserWindow
+
+@val external currentWindow: browserWindow = "window"
+@get external parentWindow: browserWindow => browserWindow = "parent"
+
+module Bindings = WindowTransport.Child.Make({
+  type parentWindow = browserWindow
+  let parentWindow = parentWindow(currentWindow)
+  let parentOrigin = "http://127.0.0.1:4173"
+  let requestTimeoutMs = 500
+})
+
+module TestRuntime = Runtime.Make(Bindings)
+open WindowTransportBrowserMessages__test
+
+let lastNotice = ref(None)
+
+let handler:
+  type response. (Types.message<response>, unit) => Response.t<response> =
+  (message, _sender) => {
+    switch message {
+    | Ping(value) => Response.now(`child:${value}`)
+    | AskReverse(value) => Response.later(TestRuntime.sendMessage(Reverse(value)))
+    | Notice(value) => {
+        lastNotice := Some(value)
+        Response.none
+      }
+    | GetNotice => Response.now(lastNotice.contents)
+    | Fail => JsError.throwWithMessage("Child handler failed")
+    | Never => Response.none
+    | Uncloneable(_) => Response.now("unexpected")
+    | _ => Response.none
+    }
+  }
+
+TestRuntime.OnMessage.addListener(handler)
+Bindings.listen()->Result.getOrThrow

--- a/src/WindowTransportParent__test.res
+++ b/src/WindowTransportParent__test.res
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 BlueHotDog
+ * SPDX-License-Identifier: MIT
+ */
+
+type browserWindow
+type document
+type element
+
+@val external currentWindow: browserWindow = "window"
+@val external currentDocument: document = "document"
+@send external getElementById: (document, string) => Nullable.t<element> = "getElementById"
+@get external contentWindow: element => browserWindow = "contentWindow"
+@send external addEventListener: (element, string, unit => unit) => unit = "addEventListener"
+@send external removeEventListener: (element, string, unit => unit) => unit = "removeEventListener"
+
+let iframe = currentDocument->getElementById("child")->Nullable.toOption->Option.getOrThrow
+
+module Bindings = WindowTransport.Parent.Make({
+  type targetWindow = browserWindow
+  type loadEvent = unit
+  let targetOrigin = "http://127.0.0.1:4174"
+  let targetWindow = () => iframe->contentWindow
+  let addLoadListener = listener => addEventListener(iframe, "load", listener)
+  let removeLoadListener = listener => removeEventListener(iframe, "load", listener)
+  let requestTimeoutMs = 500
+})
+
+module TestRuntime = Runtime.Make(Bindings)
+open WindowTransportBrowserMessages__test
+
+let handler:
+  type response. (Types.message<response>, unit) => Response.t<response> =
+  (message, _sender) => {
+    switch message {
+    | Reverse(value) => Response.now(`parent:${value}`)
+    | _ => Response.none
+    }
+  }
+
+TestRuntime.OnMessage.addListener(handler)
+
+let api: Dict.t<Obj.t> = Dict.make()
+api->Dict.set("connect", Obj.magic(Bindings.connect))
+api->Dict.set("ping", Obj.magic(value => TestRuntime.sendMessage(Ping(value))))
+api->Dict.set("reverse", Obj.magic(value => TestRuntime.sendMessage(AskReverse(value))))
+api->Dict.set("cast", Obj.magic(value => TestRuntime.cast(Notice(value))))
+api->Dict.set("notice", Obj.magic(() => TestRuntime.sendMessage(GetNotice)))
+api->Dict.set("fail", Obj.magic(() => TestRuntime.sendMessage(Fail)))
+api->Dict.set("timeout", Obj.magic(() => TestRuntime.sendMessage(Never)))
+api->Dict.set(
+  "uncloneable",
+  Obj.magic(() => TestRuntime.sendMessage(Uncloneable(Obj.magic(() => ())))),
+)
+api->Dict.set(
+  "large",
+  Obj.magic(async () => {
+    let value = "x"->String.repeat(MessageChunker.defaultChunkSize + 1000)
+    let response = await TestRuntime.sendMessage(Ping(value))
+    response === `child:${value}`
+  }),
+)
+api->Dict.set("close", Obj.magic(TestRuntime.close))
+api->Dict.set("isOpen", Obj.magic(TestRuntime.isContextValid))
+
+(Obj.magic(currentWindow): Dict.t<Obj.t>)->Dict.set("reworkerTest", api->Obj.magic)

--- a/src/bindings/BrowserWindow.res
+++ b/src/bindings/BrowserWindow.res
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025 BlueHotDog
+ * SPDX-License-Identifier: MIT
+ */
+
+type t
+
+@val external current: t = "window"
+@send external postMessage: (t, 'a, string, array<MessagePort.t>) => unit = "postMessage"
+@send external addEventListener: (t, string, 'event => unit) => unit = "addEventListener"
+@send external removeEventListener: (t, string, 'event => unit) => unit = "removeEventListener"

--- a/src/bindings/MessageChannel.res
+++ b/src/bindings/MessageChannel.res
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2025 BlueHotDog
+ * SPDX-License-Identifier: MIT
+ */
+
+type t
+
+@new external make: unit => t = "MessageChannel"
+@get external port1: t => MessagePort.t = "port1"
+@get external port2: t => MessagePort.t = "port2"

--- a/src/bindings/MessageEvent.res
+++ b/src/bindings/MessageEvent.res
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025 BlueHotDog
+ * SPDX-License-Identifier: MIT
+ */
+
+type t
+
+@get external data: t => Obj.t = "data"
+@get external origin: t => string = "origin"
+@get external source: t => BrowserWindow.t = "source"
+@get external ports: t => array<MessagePort.t> = "ports"

--- a/src/bindings/MessagePort.res
+++ b/src/bindings/MessagePort.res
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025 BlueHotDog
+ * SPDX-License-Identifier: MIT
+ */
+
+type t
+
+@send external start: t => unit = "start"
+@send external close: t => unit = "close"
+@send external postMessage: (t, 'a) => unit = "postMessage"
+@send external addEventListener: (t, string, 'event => unit) => unit = "addEventListener"


### PR DESCRIPTION
## Summary
- move request correlation, remote errors, timeouts, casts, and teardown into the shared runtime protocol
- add secure parent and child MessagePort bindings with exact origin/source validation, readiness, reload reconnection, and clone/messageerror handling
- add independently bundled two-origin browser coverage and document the new binding contract

## Breaking change
- replace the callback-style Runtime.Make binding contract with an ordered lifecycle-aware duplex transport contract

## Verification
- make test
- make test-browser
- make analyze
- ReScript 12.0 compatibility build
- npm audit --audit-level moderate

Fixes #18